### PR TITLE
Shift scheduling   crud

### DIFF
--- a/data_processor.js
+++ b/data_processor.js
@@ -40,7 +40,7 @@ exports.sequelize = sequelize;
 // Sync the table schema with the database
 exports.initialize = function initialize() {
     return new Promise ((resolve, reject) => {
-        sequelize.sync({alter: true}) // update table if columns, etc changes, but does not drop table
+        sequelize.sync({alter: false}) // doesn't update table columns, since there is a limit of 64 updates
         .then(()=>{
             console.log("Sync successful.");
             resolve();


### PR DESCRIPTION
Changed tables to not update the column structure to avoid the 64 index per table limit. Each Time the server starts, it syncs the tables, which creates a new index, effectively meaning there is a limit of 63 restarts with the table column sync option on. Colum structures do not change, so turning the option off.